### PR TITLE
Fix for Chrome and HiDPI

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,2 @@
+syntax: glob
+*.orig

--- a/contextmenu.js
+++ b/contextmenu.js
@@ -126,12 +126,15 @@ var ContextMenu = {
 
 	"getElement": function() {
 		if (!this.element) {
-			this.element = (ELE_DIV.clone(false)
-				.addClass("CMenu")
-				.inject(document.body)
-				.addStopEvent("mousedown")
-				.grab(ELE_UL.clone(false))
-			);
+                        this.element =  (ELE_DIV.clone(false)
+                                .addClass("CMenu")
+                                .inject(document.body)
+                                .addStopEvent("mousedown")
+                                .grab(ELE_DIV.clone(false)
+                                        .setStyle("overflow-y","hidden")
+                                        .grab(ELE_UL.clone(false))
+                                )
+                        );
 		}
 
 		return this.element;

--- a/main.css
+++ b/main.css
@@ -19,7 +19,7 @@ body {
 	border: 0;
 	bottom: 0;
 	cursor: default;
-	font: menu;
+        font:  normal 8pt Tahoma, Verdana, Arial, Helvetica, sans-serif;
 	height: 100%;
 	left: 0;
 	position: absolute;
@@ -1569,7 +1569,7 @@ NOTE: The following is an ugly hack, but a necessary one if we want the settings
 	border: 1px solid #A7A6AA;
 	box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.30), 0 0 4px rgba(0, 0, 0, 0.20);
 	display: none;
-	overflow-y: hidden;
+        overflow: visible;
 	position: fixed;
 	z-index: 100000;
 }
@@ -1604,7 +1604,11 @@ NOTE: The following is an ugly hack, but a necessary one if we want the settings
 	color: #C0C0C0 !important;
 }
 
-.CMenu a.exp { background: transparent url(./images/menuexp.png) no-repeat scroll 0 center; }
+.CMenu a.exp { 
+        background: transparent url(./images/menuexp.png) no-repeat scroll 0 center; 
+        background-position: right center;
+}
+
 .CMenu a.sel { background: transparent url(./images/menusel.png) no-repeat scroll 5px center; }
 .CMenu a.check { background: transparent url(./images/menucheck.png) no-repeat scroll 5px center; }
 


### PR DESCRIPTION
Hi,
I modified the css to avoid using the font: menu. In Chrome on a Windows HiDPI screen was making font's huge.

Moreover, in Chrome (and Firefox) there is a bug where the overflow-y: hidden is effecting the capability of contained controls to show if they overflow the parent just on the x axis. I didn't go into detail on reading why it happens, apart that it depends from settings inherited from parent divs. The solution was to put an overflow:visible in CMenu and creating one more div with overflow-y:hidden. I think the problem sit in the fact that there is an overflow:hidden in one of the parents.

Last is that I use Mercurial and because of it I added an .hgignore.

Best,
Tommaso
